### PR TITLE
Updated API URI to capture all issues

### DIFF
--- a/src/report-generator.js
+++ b/src/report-generator.js
@@ -26,7 +26,7 @@ module.exports = {
   generate: function (config) {
 
     var options = {
-      uri: 'https://api.github.com/repos/' + config.owner + '/' + config.repo + '/issues',
+      uri: 'https://api.github.com/repos/' + config.owner + '/' + config.repo + '/issues?state=all',
       headers: {
         'User-Agent': 'github-issue-reports'
       }


### PR DESCRIPTION
Added the necessary parameters to capture all issues for a project, as the Github API by default will only provide open issues.  According to the docs [0], the default state filter is "open".

This addresses Issue #7 

[0] https://developer.github.com/v3/issues/#list-issues